### PR TITLE
大文字変換のロジック変更

### DIFF
--- a/bin/anyenv-lazyload
+++ b/bin/anyenv-lazyload
@@ -6,12 +6,13 @@ for env in $(/bin/ls $ANYENV_ROOT/envs/)
 do
 
   shims=${shims}$ANYENV_ROOT/envs/$env/shims:
+  ENV_ROOT=$(echo ${env} | awk '{print toupper($0)}')_ROOT
 
   # init on call **env
   cat <<EOS
 function ${env}() {
   unset -f ${env}
-  export ${env^^}_ROOT="$ANYENV_ROOT/envs/$env"
+  export ${ENV_ROOT}="$ANYENV_ROOT/envs/$env"
   export PATH=$ANYENV_ROOT/envs/${env}/bin:\${PATH}
   eval "\$(${env} init - \${SHELL})"
   ${env} \$@


### PR DESCRIPTION
こんにちは、初めまして。
anyenv-lazyload、便利そうなので使わせて頂いてます。

大文字変換のロジックがbash専用の記法だったので、awkを使った形式にしてみました。
もしよろしければ見てみて下さい。